### PR TITLE
Upgrade to httpOnly cookies for session data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -584,9 +584,9 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
-      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
+      "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -637,21 +637,21 @@
       }
     },
     "node_modules/@lottiefiles/dotlottie-react": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@lottiefiles/dotlottie-react/-/dotlottie-react-0.12.0.tgz",
-      "integrity": "sha512-33Tsd67vlotrm43R8oko30Krwyuqb0YdOLra7L5m2mVfrTvDPEDBt8jfjgiveoLJ0jG/FlTLiCPXi/vCaBSXrg==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@lottiefiles/dotlottie-react/-/dotlottie-react-0.12.1.tgz",
+      "integrity": "sha512-8l0db31gqozQMC2ZfzV6NWN1cit/NOlevVgS98qC2N4vugS6CZ6IWE4EfLLJEa9DILSinENDE4K85+eIJw4MOQ==",
       "license": "MIT",
       "dependencies": {
-        "@lottiefiles/dotlottie-web": "0.38.2"
+        "@lottiefiles/dotlottie-web": "0.39.0"
       },
       "peerDependencies": {
         "react": "^17 || ^18 || ^19"
       }
     },
     "node_modules/@lottiefiles/dotlottie-web": {
-      "version": "0.38.2",
-      "resolved": "https://registry.npmjs.org/@lottiefiles/dotlottie-web/-/dotlottie-web-0.38.2.tgz",
-      "integrity": "sha512-01d+UjJ8NG7ZStYQxtb8FPzknzGmauG7gEkcH+wHfSdiSQJY9PoBNVSTB9V6F5hAnmFqOxaocTtd7TIEEnzMnA==",
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/@lottiefiles/dotlottie-web/-/dotlottie-web-0.39.0.tgz",
+      "integrity": "sha512-kJWL6NEtbXQQHFK8kMfNte/5vuTHjFhL11a30s4PJSikao8IeEu+hLJH72flWHyTLpL4tmnxW3WkTKUwZ8Osug==",
       "license": "MIT"
     },
     "node_modules/@next/env": {
@@ -902,9 +902,9 @@
       }
     },
     "node_modules/@restart/ui": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@restart/ui/-/ui-1.9.1.tgz",
-      "integrity": "sha512-qghR21ynHiUrpcIkKCoKYB+3rJtezY5Y7ikrwradCL+7hZHdQ2Ozc5ffxtpmpahoAGgc31gyXaSx2sXXaThmqA==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@restart/ui/-/ui-1.9.2.tgz",
+      "integrity": "sha512-MWWqJqSyqUWWPBOOiRQrX57CBc/9CoYONg7sE+uag72GCAuYrHGU5c49vU5s4BUSBgiKNY6rL7TULqGDrouUaA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
@@ -923,9 +923,9 @@
       }
     },
     "node_modules/@restart/ui/node_modules/@restart/hooks": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.5.0.tgz",
-      "integrity": "sha512-wS+h6IusJCPjTkmOOrRZxIPICD/mtFA3PRZviutoM23/b7akyDGfZF/WS+nIFk27u7JDhPE2+0GBdZxjSqHZkg==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.5.1.tgz",
+      "integrity": "sha512-EMoH04NHS1pbn07iLTjIjgttuqb7qu4+/EyhAx27MHpoENcB2ZdSsLTNxmKD+WEPnZigo62Qc8zjGnNxoSE/5Q==",
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.3"
@@ -973,9 +973,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.62.7",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.62.7.tgz",
-      "integrity": "sha512-fgpfmwatsrUal6V+8EC2cxZIQVl9xvL7qYa03gsdsCy985UTUlS4N+/3hCzwR0PclYDqisca2AqR1BVgJGpUDA==",
+      "version": "5.62.15",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.62.15.tgz",
+      "integrity": "sha512-wT20X14CxcWY8YLJ/1pnsXn/y1Q2uRJZYWW93PWRtZt+3/JlGZyiyTcO4pGnqycnP7CokCROAyatsraosqZsDA==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -983,12 +983,12 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.62.7",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.62.7.tgz",
-      "integrity": "sha512-+xCtP4UAFDTlRTYyEjLx0sRtWyr5GIk7TZjZwBu4YaNahi3Rt2oMyRqfpfVrtwsqY2sayP4iXVCwmC+ZqqFmuw==",
+      "version": "5.62.15",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.62.15.tgz",
+      "integrity": "sha512-Ny3xxsOWmEQCFyHiV3CF7t6+QAV+LpBEREiXyllKR4+tStyd8smOAa98ZHmEx0ZNy36M31K8enifB5wTSYAKJw==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.62.7"
+        "@tanstack/query-core": "5.62.15"
       },
       "funding": {
         "type": "github",
@@ -1012,10 +1012,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.14",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
+      "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
-      "version": "19.0.1",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.1.tgz",
-      "integrity": "sha512-YW6614BDhqbpR5KtUYzTA+zlA7nayzJRA9ljz9CQoxthR0sDisYZLuvSMsil36t4EH/uAt8T52Xb4sVw17G+SQ==",
+      "version": "19.0.2",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.2.tgz",
+      "integrity": "sha512-USU8ZI/xyKJwFTpjSVIrSeHBVAGagkHQKPNbxeWwql/vDmnTIBgx+TJnhFnj1NXgz8XfprU0egV2dROLGpsBEg==",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -1037,17 +1043,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.18.0.tgz",
-      "integrity": "sha512-NR2yS7qUqCL7AIxdJUQf2MKKNDVNaig/dEB0GBLU7D+ZdHgK1NoH/3wsgO3OnPVipn51tG3MAwaODEGil70WEw==",
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.19.0.tgz",
+      "integrity": "sha512-NggSaEZCdSrFddbctrVjkVZvFC6KGfKfNK0CU7mNK/iKHGKbzT4Wmgm08dKpcZECBu9f5FypndoMyRHkdqfT1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.18.0",
-        "@typescript-eslint/type-utils": "8.18.0",
-        "@typescript-eslint/utils": "8.18.0",
-        "@typescript-eslint/visitor-keys": "8.18.0",
+        "@typescript-eslint/scope-manager": "8.19.0",
+        "@typescript-eslint/type-utils": "8.19.0",
+        "@typescript-eslint/utils": "8.19.0",
+        "@typescript-eslint/visitor-keys": "8.19.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -1067,16 +1073,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.18.0.tgz",
-      "integrity": "sha512-hgUZ3kTEpVzKaK3uNibExUYm6SKKOmTU2BOxBSvOYwtJEPdVQ70kZJpPjstlnhCHcuc2WGfSbpKlb/69ttyN5Q==",
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.19.0.tgz",
+      "integrity": "sha512-6M8taKyOETY1TKHp0x8ndycipTVgmp4xtg5QpEZzXxDhNvvHOJi5rLRkLr8SK3jTgD5l4fTlvBiRdfsuWydxBw==",
       "dev": true,
-      "license": "MITClause",
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.18.0",
-        "@typescript-eslint/types": "8.18.0",
-        "@typescript-eslint/typescript-estree": "8.18.0",
-        "@typescript-eslint/visitor-keys": "8.18.0",
+        "@typescript-eslint/scope-manager": "8.19.0",
+        "@typescript-eslint/types": "8.19.0",
+        "@typescript-eslint/typescript-estree": "8.19.0",
+        "@typescript-eslint/visitor-keys": "8.19.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1092,14 +1098,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.18.0.tgz",
-      "integrity": "sha512-PNGcHop0jkK2WVYGotk/hxj+UFLhXtGPiGtiaWgVBVP1jhMoMCHlTyJA+hEj4rszoSdLTK3fN4oOatrL0Cp+Xw==",
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.19.0.tgz",
+      "integrity": "sha512-hkoJiKQS3GQ13TSMEiuNmSCvhz7ujyqD1x3ShbaETATHrck+9RaDdUbt+osXaUuns9OFwrDTTrjtwsU8gJyyRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.18.0",
-        "@typescript-eslint/visitor-keys": "8.18.0"
+        "@typescript-eslint/types": "8.19.0",
+        "@typescript-eslint/visitor-keys": "8.19.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1110,14 +1116,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.18.0.tgz",
-      "integrity": "sha512-er224jRepVAVLnMF2Q7MZJCq5CsdH2oqjP4dT7K6ij09Kyd+R21r7UVJrF0buMVdZS5QRhDzpvzAxHxabQadow==",
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.19.0.tgz",
+      "integrity": "sha512-TZs0I0OSbd5Aza4qAMpp1cdCYVnER94IziudE3JU328YUHgWu9gwiwhag+fuLeJ2LkWLXI+F/182TbG+JaBdTg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.18.0",
-        "@typescript-eslint/utils": "8.18.0",
+        "@typescript-eslint/typescript-estree": "8.19.0",
+        "@typescript-eslint/utils": "8.19.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.3.0"
       },
@@ -1134,9 +1140,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.18.0.tgz",
-      "integrity": "sha512-FNYxgyTCAnFwTrzpBGq+zrnoTO4x0c1CKYY5MuUTzpScqmY5fmsh2o3+57lqdI3NZucBDCzDgdEbIaNfAjAHQA==",
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.19.0.tgz",
+      "integrity": "sha512-8XQ4Ss7G9WX8oaYvD4OOLCjIQYgRQxO+qCiR2V2s2GxI9AUpo7riNwo6jDhKtTcaJjT8PY54j2Yb33kWtSJsmA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1148,14 +1154,14 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.18.0.tgz",
-      "integrity": "sha512-rqQgFRu6yPkauz+ms3nQpohwejS8bvgbPyIDq13cgEDbkXt4LH4OkDMT0/fN1RUtzG8e8AKJyDBoocuQh8qNeg==",
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.19.0.tgz",
+      "integrity": "sha512-WW9PpDaLIFW9LCbucMSdYUuGeFUz1OkWYS/5fwZwTA+l2RwlWFdJvReQqMUMBw4yJWJOfqd7An9uwut2Oj8sLw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.18.0",
-        "@typescript-eslint/visitor-keys": "8.18.0",
+        "@typescript-eslint/types": "8.19.0",
+        "@typescript-eslint/visitor-keys": "8.19.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -1185,9 +1191,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/fast-glob": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
-      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1195,7 +1201,7 @@
         "@nodelib/fs.walk": "^1.2.3",
         "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
+        "micromatch": "^4.0.8"
       },
       "engines": {
         "node": ">=8.6.0"
@@ -1231,16 +1237,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.18.0.tgz",
-      "integrity": "sha512-p6GLdY383i7h5b0Qrfbix3Vc3+J2k6QWw6UMUeY5JGfm3C5LbZ4QIZzJNoNOfgyRe0uuYKjvVOsO/jD4SJO+xg==",
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.19.0.tgz",
+      "integrity": "sha512-PTBG+0oEMPH9jCZlfg07LCB2nYI0I317yyvXGfxnvGvw4SHIOuRnQ3kadyyXY6tGdChusIHIbM5zfIbp4M6tCg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.18.0",
-        "@typescript-eslint/types": "8.18.0",
-        "@typescript-eslint/typescript-estree": "8.18.0"
+        "@typescript-eslint/scope-manager": "8.19.0",
+        "@typescript-eslint/types": "8.19.0",
+        "@typescript-eslint/typescript-estree": "8.19.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1255,13 +1261,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.18.0.tgz",
-      "integrity": "sha512-pCh/qEA8Lb1wVIqNvBke8UaRjJ6wrAWkJO5yyIbs8Yx6TNGYyfNjOo61tLv+WwLvoLPp4BQ8B7AHKijl8NGUfw==",
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.19.0.tgz",
+      "integrity": "sha512-mCFtBbFBJDCNCWUl5y6sZSCHXw1DEFEk3c/M3nRK2a4XUB8StGFtmcEMizdjKuBzB6e/smJAAWYug3VrdLMr1w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.18.0",
+        "@typescript-eslint/types": "8.19.0",
         "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
@@ -1417,14 +1423,14 @@
       }
     },
     "node_modules/array-buffer-byte-length": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
-      "integrity": "sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.5",
-        "is-array-buffer": "^3.0.4"
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1497,16 +1503,16 @@
       }
     },
     "node_modules/array.prototype.flat": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.2.tgz",
-      "integrity": "sha512-djYB+Zx2vLewY8RWlNCUdHjDXs2XOgm602S9E7P/UpHgfeHL00cRiIF+IN/G/aUJ7kGPb6yO/ErDI5V2s8iycA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "es-shim-unscopables": "^1.0.0"
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1516,16 +1522,16 @@
       }
     },
     "node_modules/array.prototype.flatmap": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.2.tgz",
-      "integrity": "sha512-Ewyx0c9PmpcsByhSW4r+9zDU7sGjFc86qf/kKtuSCRdhfbk0SNLLkaT5qvcHnRGgc5NP/ly/y+qkXkqONX54CQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "es-shim-unscopables": "^1.0.0"
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1552,20 +1558,19 @@
       }
     },
     "node_modules/arraybuffer.prototype.slice": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.3.tgz",
-      "integrity": "sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "array-buffer-byte-length": "^1.0.1",
-        "call-bind": "^1.0.5",
+        "call-bind": "^1.0.8",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.22.3",
-        "es-errors": "^1.2.1",
-        "get-intrinsic": "^1.2.3",
-        "is-array-buffer": "^3.0.4",
-        "is-shared-array-buffer": "^1.0.2"
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1741,6 +1746,23 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/call-bound": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
+      "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1762,9 +1784,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001687",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001687.tgz",
-      "integrity": "sha512-0S/FDhf4ZiqrTUiQ39dKeUjYRjkv7lOZU1Dgif2rIqrTzX/1wV2hfKu9TOm1IHkdSijfLswxTFzl/cvir+SLSQ==",
+      "version": "1.0.30001690",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001690.tgz",
+      "integrity": "sha512-5ExiE3qQN6oF8Clf8ifIDcMRCRE/dMGcETG/XGMD8/XiXm6HXQgQTh1yZYLXXpSOsEUlJm1Xr7kGULZTuGtP/w==",
       "funding": [
         {
           "type": "opencollective",
@@ -1973,15 +1995,15 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/data-view-buffer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
-      "integrity": "sha512-0lht7OugA5x3iJLOWFhWK/5ehONdprk0ISXqVFn/NFrDu+cuc8iADFrGQz5BnRK7LLU3JmkbXSxaqX+/mXYtUA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.6",
+        "call-bound": "^1.0.3",
         "es-errors": "^1.3.0",
-        "is-data-view": "^1.0.1"
+        "is-data-view": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1991,31 +2013,31 @@
       }
     },
     "node_modules/data-view-byte-length": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.1.tgz",
-      "integrity": "sha512-4J7wRJD3ABAzr8wP+OcIcqq2dlUKp4DVflx++hs5h5ZKydWMI6/D/fAot+yh6g2tHh8fLFTvNOaVN357NvSrOQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bound": "^1.0.3",
         "es-errors": "^1.3.0",
-        "is-data-view": "^1.0.1"
+        "is-data-view": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "url": "https://github.com/sponsors/inspect-js"
       }
     },
     "node_modules/data-view-byte-offset": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.0.tgz",
-      "integrity": "sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.6",
+        "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
         "is-data-view": "^1.0.1"
       },
@@ -2170,13 +2192,13 @@
       }
     },
     "node_modules/dunder-proto": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.0.tgz",
-      "integrity": "sha512-9+Sj30DIu+4KvHqMfLUGLFYL2PkURSYMVXJyXe92nFRvlYq5hBjLEhblKB+vkd/WVlUYMWigiY07T91Fkk0+4A==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
+        "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
         "gopd": "^1.2.0"
       },
@@ -2206,9 +2228,9 @@
       "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.17.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
-      "integrity": "sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==",
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.0.tgz",
+      "integrity": "sha512-0/r0MySGYG8YqlayBZ6MuCfECmHFdJ5qyPh8s8wa5Hnm6SaFLSK1VYCbj+NKp090Nm1caZhD+QTnmxO7esYGyQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2220,58 +2242,63 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.23.5",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.5.tgz",
-      "integrity": "sha512-vlmniQ0WNPwXqA0BnmwV3Ng7HxiGlh6r5U6JcTMNx8OilcAGqVJBHJcPjqOMaczU9fRuRK5Px2BdVyPRnKMMVQ==",
+      "version": "1.23.9",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.9.tgz",
+      "integrity": "sha512-py07lI0wjxAC/DcfK1S6G7iANonniZwTISvdPzk9hzeH0IZIshbuuFxLIU96OyF89Yb9hiqWn8M/bY83KY5vzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "array-buffer-byte-length": "^1.0.1",
-        "arraybuffer.prototype.slice": "^1.0.3",
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.7",
-        "data-view-buffer": "^1.0.1",
-        "data-view-byte-length": "^1.0.1",
-        "data-view-byte-offset": "^1.0.0",
-        "es-define-property": "^1.0.0",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
         "es-object-atoms": "^1.0.0",
-        "es-set-tostringtag": "^2.0.3",
-        "es-to-primitive": "^1.2.1",
-        "function.prototype.name": "^1.1.6",
-        "get-intrinsic": "^1.2.4",
-        "get-symbol-description": "^1.0.2",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.0",
+        "get-symbol-description": "^1.1.0",
         "globalthis": "^1.0.4",
-        "gopd": "^1.0.1",
+        "gopd": "^1.2.0",
         "has-property-descriptors": "^1.0.2",
-        "has-proto": "^1.0.3",
-        "has-symbols": "^1.0.3",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
         "hasown": "^2.0.2",
-        "internal-slot": "^1.0.7",
-        "is-array-buffer": "^3.0.4",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
         "is-callable": "^1.2.7",
-        "is-data-view": "^1.0.1",
-        "is-negative-zero": "^2.0.3",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.3",
-        "is-string": "^1.0.7",
-        "is-typed-array": "^1.1.13",
-        "is-weakref": "^1.0.2",
+        "is-data-view": "^1.0.2",
+        "is-regex": "^1.2.1",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.0",
+        "math-intrinsics": "^1.1.0",
         "object-inspect": "^1.13.3",
         "object-keys": "^1.1.1",
-        "object.assign": "^4.1.5",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
         "regexp.prototype.flags": "^1.5.3",
-        "safe-array-concat": "^1.1.2",
-        "safe-regex-test": "^1.0.3",
-        "string.prototype.trim": "^1.2.9",
-        "string.prototype.trimend": "^1.0.8",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
         "string.prototype.trimstart": "^1.0.8",
-        "typed-array-buffer": "^1.0.2",
-        "typed-array-byte-length": "^1.0.1",
-        "typed-array-byte-offset": "^1.0.2",
-        "typed-array-length": "^1.0.6",
-        "unbox-primitive": "^1.0.2",
-        "which-typed-array": "^1.1.15"
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.18"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2301,27 +2328,28 @@
       }
     },
     "node_modules/es-iterator-helpers": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.2.0.tgz",
-      "integrity": "sha512-tpxqxncxnpw3c93u8n3VOzACmRFoVmWJqbWXvX/JfKbkhBw1oslgPrUfeSt2psuqyEJFD6N/9lg5i7bsKpoq+Q==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.2.1.tgz",
+      "integrity": "sha512-uDn+FE1yrDzyC0pCo961B2IHbdM8y/ACZsKD4dG6WqrjV53BADjwa7D+1aom2rsNVfLyDgU/eigvlJGJ08OQ4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.3",
+        "es-abstract": "^1.23.6",
         "es-errors": "^1.3.0",
         "es-set-tostringtag": "^2.0.3",
         "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
+        "get-intrinsic": "^1.2.6",
         "globalthis": "^1.0.4",
-        "gopd": "^1.0.1",
+        "gopd": "^1.2.0",
         "has-property-descriptors": "^1.0.2",
-        "has-proto": "^1.0.3",
-        "has-symbols": "^1.0.3",
-        "internal-slot": "^1.0.7",
-        "iterator.prototype": "^1.1.3",
-        "safe-array-concat": "^1.1.2"
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "iterator.prototype": "^1.1.4",
+        "safe-array-concat": "^1.1.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2341,15 +2369,16 @@
       }
     },
     "node_modules/es-set-tostringtag": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
-      "integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "get-intrinsic": "^1.2.4",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
         "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.1"
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2540,9 +2569,9 @@
       }
     },
     "node_modules/eslint-import-resolver-typescript/node_modules/fast-glob": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
-      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2550,7 +2579,7 @@
         "@nodelib/fs.walk": "^1.2.3",
         "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
+        "micromatch": "^4.0.8"
       },
       "engines": {
         "node": ">=8.6.0"
@@ -2695,29 +2724,29 @@
       }
     },
     "node_modules/eslint-plugin-react": {
-      "version": "7.37.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.2.tgz",
-      "integrity": "sha512-EsTAnj9fLVr/GZleBLFbj/sSuXeWmp1eXIN60ceYnZveqEaUCyW4X+Vh4WTdUhCkW4xutXYqTXCUSyqD4rB75w==",
+      "version": "7.37.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.3.tgz",
+      "integrity": "sha512-DomWuTQPFYZwF/7c9W2fkKkStqZmBd3uugfqBYLdkZ3Hii23WzZuOLUskGxB8qkSKqftxEeGL1TB2kMhrce0jA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
-        "array.prototype.flatmap": "^1.3.2",
+        "array.prototype.flatmap": "^1.3.3",
         "array.prototype.tosorted": "^1.1.4",
         "doctrine": "^2.1.0",
-        "es-iterator-helpers": "^1.1.0",
+        "es-iterator-helpers": "^1.2.1",
         "estraverse": "^5.3.0",
         "hasown": "^2.0.2",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.1.2",
         "object.entries": "^1.1.8",
         "object.fromentries": "^2.0.8",
-        "object.values": "^1.2.0",
+        "object.values": "^1.2.1",
         "prop-types": "^15.8.1",
         "resolve": "^2.0.0-next.5",
         "semver": "^6.3.1",
-        "string.prototype.matchall": "^4.0.11",
+        "string.prototype.matchall": "^4.0.12",
         "string.prototype.repeat": "^1.0.0"
       },
       "engines": {
@@ -2927,9 +2956,9 @@
       "license": "MIT"
     },
     "node_modules/fastq": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
-      "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.18.0.tgz",
+      "integrity": "sha512-QKHXPW0hD8g4UET03SdOdunzSouc9N4AuHdsX8XNcTsuz+yYFILVNIX4l9yHABMhiEI9Db0JTTIpu0wB+Y1QQw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3095,16 +3124,18 @@
       }
     },
     "node_modules/function.prototype.name": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
-      "integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "functions-have-names": "^1.2.3"
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "functions-have-names": "^1.2.3",
+        "hasown": "^2.0.2",
+        "is-callable": "^1.2.7"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3124,20 +3155,22 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.5.tgz",
-      "integrity": "sha512-Y4+pKa7XeRUPWFNvOOYHkRYrfzW07oraURSvjDmRVOJ748OrVmeXtpE4+GCEHncjCjkTxPNRt8kEbxDhsn6VTg==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
+      "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "dunder-proto": "^1.0.0",
+        "call-bind-apply-helpers": "^1.0.1",
         "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
         "function-bind": "^1.1.2",
+        "get-proto": "^1.0.0",
         "gopd": "^1.2.0",
         "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2"
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3146,16 +3179,30 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/get-symbol-description": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.2.tgz",
-      "integrity": "sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==",
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.5",
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
         "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.4"
+        "get-intrinsic": "^1.2.6"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3289,11 +3336,14 @@
       }
     },
     "node_modules/has-bigints": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
-      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -3443,15 +3493,15 @@
       "license": "ISC"
     },
     "node_modules/internal-slot": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
-      "integrity": "sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "hasown": "^2.0.0",
-        "side-channel": "^1.0.4"
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3467,14 +3517,15 @@
       }
     },
     "node_modules/is-array-buffer": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
-      "integrity": "sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.2.1"
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3491,13 +3542,16 @@
       "optional": true
     },
     "node_modules/is-async-function": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.0.0.tgz",
-      "integrity": "sha512-Y1JXKrfykRJGdlDwdKlLpLyMIiWqWvuSd17TvZk68PLAOGOoF4Xyav1z0Xhoi+gCYjZVeC5SI+hYFOfvXmGRCA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.0.tgz",
+      "integrity": "sha512-GExz9MtyhlZyXYLxzlJRj5WUCE661zhDa1Yna52CN57AJsymh+DvXXjyveSioqSRdxvUrdKdvqB1b5cVKsNpWQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3536,13 +3590,13 @@
       }
     },
     "node_modules/is-boolean-object": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.0.tgz",
-      "integrity": "sha512-kR5g0+dXf/+kXnqI+lu0URKYPKgICtHGGNCDSB10AaUFj3o/HkB3u7WfpRBJGFopxxY0oH3ux7ZsDjLtK7xqvw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.1.tgz",
+      "integrity": "sha512-l9qO6eFlUETHtuihLcYOaLKByJ1f+N4kthcU9YjHy3N+B3hWv0y/2Nd0mu/7lTFnRQHTrSdXF50HQ3bl5fEnng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bound": "^1.0.2",
         "has-tostringtag": "^1.0.2"
       },
       "engines": {
@@ -3576,9 +3630,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
-      "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3592,12 +3646,14 @@
       }
     },
     "node_modules/is-data-view": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.1.tgz",
-      "integrity": "sha512-AHkaJrsUVW6wq6JS8y3JnM/GJF/9cf+k20+iDzlSaJrinEo5+7vRiteOSwBhHRiAyQATN1AmY4hwzxJKPmYf+w==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
         "is-typed-array": "^1.1.13"
       },
       "engines": {
@@ -3608,13 +3664,14 @@
       }
     },
     "node_modules/is-date-object": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
-      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3634,13 +3691,13 @@
       }
     },
     "node_modules/is-finalizationregistry": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.0.tgz",
-      "integrity": "sha512-qfMdqbAQEwBw78ZyReKnlA8ezmPdb9BemzIIip/JkjaZUhitfXDkkr+3QTboW0JrSXT1QWyYShpvnNHGZ4c4yA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7"
+        "call-bound": "^1.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3660,13 +3717,16 @@
       }
     },
     "node_modules/is-generator-function": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
-      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
+      "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.0",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3701,19 +3761,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-negative-zero": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
-      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -3725,13 +3772,13 @@
       }
     },
     "node_modules/is-number-object": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.0.tgz",
-      "integrity": "sha512-KVSZV0Dunv9DTPkhXwcZ3Q+tUc9TsaE1ZwX5J2WMvsSGS6Md8TFPun5uwh0yRdrNerI6vf/tbJxqSx4c1ZI1Lw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bound": "^1.0.3",
         "has-tostringtag": "^1.0.2"
       },
       "engines": {
@@ -3752,14 +3799,14 @@
       }
     },
     "node_modules/is-regex": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.0.tgz",
-      "integrity": "sha512-B6ohK4ZmoftlUe+uvenXSbPJFo6U37BH7oO1B3nQH8f/7h27N56s85MhUtbFJAziz5dcmuR3i8ovUl35zp8pFA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
-        "gopd": "^1.1.0",
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
         "has-tostringtag": "^1.0.2",
         "hasown": "^2.0.2"
       },
@@ -3784,13 +3831,13 @@
       }
     },
     "node_modules/is-shared-array-buffer": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.3.tgz",
-      "integrity": "sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7"
+        "call-bound": "^1.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3800,13 +3847,13 @@
       }
     },
     "node_modules/is-string": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.0.tgz",
-      "integrity": "sha512-PlfzajuF9vSo5wErv3MJAKD/nqf9ngAs1NFQYm16nUYFO2IzxJ2hcm+IOCg+EEopdykNNUhVq5cz35cAUxU8+g==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bound": "^1.0.3",
         "has-tostringtag": "^1.0.2"
       },
       "engines": {
@@ -3817,15 +3864,15 @@
       }
     },
     "node_modules/is-symbol": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.0.tgz",
-      "integrity": "sha512-qS8KkNNXUZ/I+nX6QT8ZS1/Yx0A444yhzdTKxCzKkNjQ9sHErBxJnJAgh+f5YhusYECEcjo4XcyH87hn6+ks0A==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
-        "has-symbols": "^1.0.3",
-        "safe-regex-test": "^1.0.3"
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3835,13 +3882,13 @@
       }
     },
     "node_modules/is-typed-array": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
-      "integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "which-typed-array": "^1.1.14"
+        "which-typed-array": "^1.1.16"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3864,27 +3911,30 @@
       }
     },
     "node_modules/is-weakref": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
-      "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.0.tgz",
+      "integrity": "sha512-SXM8Nwyys6nT5WP6pltOwKytLV7FqQ4UiibxVmW+EIosHcmCqkkjViTb5SNssDlkCiEYRP1/pdWUKVvZBmsR2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2"
+        "call-bound": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-weakset": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.3.tgz",
-      "integrity": "sha512-LvIm3/KWzS9oRFHugab7d+M/GcBXuXX5xZkzPmN+NxihdQlZUQ4dWuSV1xR/sq6upL1TJEDrfBgRepHFdBtSNQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
-        "get-intrinsic": "^1.2.4"
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3908,17 +3958,18 @@
       "license": "ISC"
     },
     "node_modules/iterator.prototype": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.3.tgz",
-      "integrity": "sha512-FW5iMbeQ6rBGm/oKgzq2aW4KvAGpxPzYES8N4g4xNXUKpL1mclMvOe+76AcLDTvD+Ze+sOpVhgdAQEKF4L9iGQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
+      "integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "define-properties": "^1.2.1",
-        "get-intrinsic": "^1.2.1",
-        "has-symbols": "^1.0.3",
-        "reflect.getprototypeof": "^1.0.4",
-        "set-function-name": "^2.0.1"
+        "define-data-property": "^1.1.4",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "get-proto": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "set-function-name": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3941,9 +3992,9 @@
       }
     },
     "node_modules/jiti": {
-      "version": "1.21.6",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.6.tgz",
-      "integrity": "sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==",
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -4124,6 +4175,16 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -4402,15 +4463,17 @@
       }
     },
     "node_modules/object.assign": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
-      "integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.5",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
         "define-properties": "^1.2.1",
-        "has-symbols": "^1.0.3",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
         "object-keys": "^1.1.1"
       },
       "engines": {
@@ -4470,13 +4533,14 @@
       }
     },
     "node_modules/object.values": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.0.tgz",
-      "integrity": "sha512-yBYjY9QX2hnRmZHAjG/f13MzmBzxzYgQhFrke06TTyKY5zSTEqkOeukBzIdVA3j3ulu8Qa3MbVFShV7T2RmGtQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
+      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
         "define-properties": "^1.2.1",
         "es-object-atoms": "^1.0.0"
       },
@@ -4523,6 +4587,24 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/p-limit": {
@@ -4911,14 +4993,15 @@
       }
     },
     "node_modules/react-bootstrap": {
-      "version": "2.10.6",
-      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.10.6.tgz",
-      "integrity": "sha512-fNvKytSp0nHts1WRnRBJeBEt+I9/ZdrnhIjWOucEduRNvFRU1IXjZueDdWnBiqsTSJ7MckQJi9i/hxGolaRq+g==",
+      "version": "2.10.7",
+      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.10.7.tgz",
+      "integrity": "sha512-w6mWb3uytB5A18S2oTZpYghcOUK30neMBBvZ/bEfA+WIF2dF4OGqjzoFVMpVXBjtyf92gkmRToHlddiMAVhQqQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.24.7",
         "@restart/hooks": "^0.4.9",
-        "@restart/ui": "^1.9.0",
+        "@restart/ui": "^1.9.2",
+        "@types/prop-types": "^15.7.12",
         "@types/react-transition-group": "^4.4.6",
         "classnames": "^2.3.2",
         "dom-helpers": "^5.2.1",
@@ -5016,20 +5099,20 @@
       }
     },
     "node_modules/reflect.getprototypeof": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.8.tgz",
-      "integrity": "sha512-B5dj6usc5dkk8uFliwjwDHM8To5/QwdKz9JcBZ8Ic4G1f0YmeeJTtE/ZTdgRFPAfxZFiUaPhZ1Jcs4qeagItGQ==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
         "define-properties": "^1.2.1",
-        "dunder-proto": "^1.0.0",
-        "es-abstract": "^1.23.5",
+        "es-abstract": "^1.23.9",
         "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.4",
-        "gopd": "^1.2.0",
-        "which-builtin-type": "^1.2.0"
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5045,15 +5128,17 @@
       "license": "MIT"
     },
     "node_modules/regexp.prototype.flags": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.3.tgz",
-      "integrity": "sha512-vqlC04+RQoFalODCbCumG2xIOvapzVMHwsyIGM/SIE8fRhFFsXeH8/QQ+s0T0kDAhKc4k30s73/0ydkHQz6HlQ==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
         "define-properties": "^1.2.1",
         "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
         "set-function-name": "^2.0.2"
       },
       "engines": {
@@ -5064,18 +5149,21 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.8",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "is-core-module": "^2.13.0",
+        "is-core-module": "^2.16.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
       "bin": {
         "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5154,15 +5242,16 @@
       }
     },
     "node_modules/safe-array-concat": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
-      "integrity": "sha512-vj6RsCsWBCf19jIeHEfkRMw8DPiBb+DMXklQ/1SGDHOMlHdPUkZXFQ2YdplS23zESTijAcurb1aSgJA3AgMu1Q==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
+      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
-        "get-intrinsic": "^1.2.4",
-        "has-symbols": "^1.0.3",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "has-symbols": "^1.1.0",
         "isarray": "^2.0.5"
       },
       "engines": {
@@ -5172,16 +5261,33 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/safe-regex-test": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
-      "integrity": "sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==",
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.6",
         "es-errors": "^1.3.0",
-        "is-regex": "^1.1.4"
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5244,6 +5350,21 @@
         "es-errors": "^1.3.0",
         "functions-have-names": "^1.2.3",
         "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5313,16 +5434,73 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
-      "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.4",
-        "object-inspect": "^1.13.1"
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5479,24 +5657,25 @@
       }
     },
     "node_modules/string.prototype.matchall": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.11.tgz",
-      "integrity": "sha512-NUdh0aDavY2og7IbBPenWqR9exH+E26Sv8e0/eTe1tltDGZL+GtBkDAnnyBtmekfK6/Dq3MkcGtzXFEd1LQrtg==",
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
+      "integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.2",
+        "es-abstract": "^1.23.6",
         "es-errors": "^1.3.0",
         "es-object-atoms": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
-        "gopd": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "internal-slot": "^1.0.7",
-        "regexp.prototype.flags": "^1.5.2",
+        "get-intrinsic": "^1.2.6",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "regexp.prototype.flags": "^1.5.3",
         "set-function-name": "^2.0.2",
-        "side-channel": "^1.0.6"
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5517,16 +5696,19 @@
       }
     },
     "node_modules/string.prototype.trim": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.9.tgz",
-      "integrity": "sha512-klHuCNxiMZ8MlsOihJhJEBJAiMVqU3Z2nEXWfWnIqjN0gEFS9J9+IxKozWWtQGcgoa1WUZzLjKPTr4ZHNFTFxw==",
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-data-property": "^1.1.4",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.0",
-        "es-object-atoms": "^1.0.0"
+        "es-abstract": "^1.23.5",
+        "es-object-atoms": "^1.0.0",
+        "has-property-descriptors": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5536,15 +5718,19 @@
       }
     },
     "node_modules/string.prototype.trimend": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.8.tgz",
-      "integrity": "sha512-p73uL5VCHCO2BZZ6krwwQE3kCzM7NKmis8S//xEC6fQonchbum4eP6kR4DLEjQFO3Wnj3Fuo8NM0kOSjVdHjZQ==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
         "define-properties": "^1.2.1",
         "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5738,9 +5924,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "3.4.16",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.16.tgz",
-      "integrity": "sha512-TI4Cyx7gDiZ6r44ewaJmt0o6BrMCT5aK5e0rmJ/G9Xq3w7CX/5VXl/zIPEJZFUK5VEqwByyhqNPycPlvcK4ZNw==",
+      "version": "3.4.17",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
+      "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5776,9 +5962,9 @@
       }
     },
     "node_modules/tailwindcss/node_modules/fast-glob": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
-      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5786,7 +5972,7 @@
         "@nodelib/fs.walk": "^1.2.3",
         "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
+        "micromatch": "^4.0.8"
       },
       "engines": {
         "node": ">=8.6.0"
@@ -5934,32 +6120,32 @@
       }
     },
     "node_modules/typed-array-buffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.2.tgz",
-      "integrity": "sha512-gEymJYKZtKXzzBzM4jqa9w6Q1Jjm7x2d+sh19AdsD4wqnMPDYyvwpsIc2Q/835kHuo3BEQ7CjelGhfTsoBb2MQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bound": "^1.0.3",
         "es-errors": "^1.3.0",
-        "is-typed-array": "^1.1.13"
+        "is-typed-array": "^1.1.14"
       },
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/typed-array-byte-length": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.1.tgz",
-      "integrity": "sha512-3iMJ9q0ao7WE9tWcaYKIptkNBuOIcZCCT0d4MRvuuH88fEoEH62IuQe0OtraD3ebQEoTRk8XCBoknUNc1Y67pw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
         "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "has-proto": "^1.0.3",
-        "is-typed-array": "^1.1.13"
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5969,19 +6155,19 @@
       }
     },
     "node_modules/typed-array-byte-offset": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.3.tgz",
-      "integrity": "sha512-GsvTyUHTriq6o/bHcTd0vM7OQ9JEdlvluu9YISaA7+KzDzPaIzEeDFNkTfhdE3MYcNhNi0vq/LlegYgIs5yPAw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
         "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "has-proto": "^1.0.3",
-        "is-typed-array": "^1.1.13",
-        "reflect.getprototypeof": "^1.0.6"
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6027,16 +6213,19 @@
       }
     },
     "node_modules/unbox-primitive": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
-      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
+        "call-bound": "^1.0.3",
         "has-bigints": "^1.0.2",
-        "has-symbols": "^1.0.3",
-        "which-boxed-primitive": "^1.0.2"
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6137,17 +6326,17 @@
       }
     },
     "node_modules/which-boxed-primitive": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.0.tgz",
-      "integrity": "sha512-Ei7Miu/AXe2JJ4iNF5j/UphAgRoma4trE6PtisM09bPygb3egMH3YLW/befsWb1A1AxvNSFidOFTB18XtnIIng==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-bigint": "^1.1.0",
-        "is-boolean-object": "^1.2.0",
-        "is-number-object": "^1.1.0",
-        "is-string": "^1.1.0",
-        "is-symbol": "^1.1.0"
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6157,25 +6346,25 @@
       }
     },
     "node_modules/which-builtin-type": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.0.tgz",
-      "integrity": "sha512-I+qLGQ/vucCby4tf5HsLmGueEla4ZhwTBSqaooS+Y0BuxN4Cp+okmGuV+8mXZ84KDI9BA+oklo+RzKg0ONdSUA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bound": "^1.0.2",
         "function.prototype.name": "^1.1.6",
         "has-tostringtag": "^1.0.2",
         "is-async-function": "^2.0.0",
-        "is-date-object": "^1.0.5",
+        "is-date-object": "^1.1.0",
         "is-finalizationregistry": "^1.1.0",
         "is-generator-function": "^1.0.10",
-        "is-regex": "^1.1.4",
+        "is-regex": "^1.2.1",
         "is-weakref": "^1.0.2",
         "isarray": "^2.0.5",
-        "which-boxed-primitive": "^1.0.2",
+        "which-boxed-primitive": "^1.1.0",
         "which-collection": "^1.0.2",
-        "which-typed-array": "^1.1.15"
+        "which-typed-array": "^1.1.16"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6204,16 +6393,17 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.16.tgz",
-      "integrity": "sha512-g+N+GAWiRj66DngFwHvISJd+ITsyphZvD1vChfVg6cEdnzy53GzB3oy0fUNlvhz7H7+MiqhYr26qxQShCpKTTQ==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.18.tgz",
+      "integrity": "sha512-qEcY+KJYlWyLH9vNbsr6/5j59AXk5ni5aakf8ldzBvGde6Iz4sxZGkJyWSAueTG7QhOvNRYb1lDdFmL5Td0QKA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
         "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
+        "gopd": "^1.2.0",
         "has-tostringtag": "^1.0.2"
       },
       "engines": {
@@ -6364,9 +6554,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.1.tgz",
-      "integrity": "sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
+      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "react-dom": "^19.0.0"
       },
       "devDependencies": {
+        "@types/cookie": "^0.6.0",
         "eslint": "^8",
         "eslint-config-next": "15.1.0",
         "postcss": "^8",
@@ -996,6 +997,13 @@
       "peerDependencies": {
         "react": "^18 || ^19"
       }
+    },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
+    "@types/cookie": "^0.6.0",
     "eslint": "^8",
     "eslint-config-next": "15.1.0",
     "postcss": "^8",

--- a/src/app/(auth)/layout.js
+++ b/src/app/(auth)/layout.js
@@ -1,74 +1,25 @@
 'use client';
 
 import '@/app/(auth)/auth.css';
-
-import apiClient from "@/utils/api";
-import { useRouter } from "next/navigation";
-import { parseCookies } from "nookies";
 import { createContext, useContext, useEffect, useState } from "react";
-import { Alert, Col, Row, Spinner } from "react-bootstrap";
+import { Alert, Col, Row } from "react-bootstrap";
 import Container from "react-bootstrap/Container";
-
 
 const AuthContext = createContext();
 
 export const useAuth = () => useContext(AuthContext); // context for child elements to get access to loading and error states
 
 export default function DashboardLayout({ children }) {
-    const [loading, setLoading] = useState(true);
     const [message, setMessage] = useState('');
     const [messageType, setMessageType] = useState('warning');
-    const router = useRouter();
-    const { token } = parseCookies();
     const [justRegistered, setJustRegistered] = useState(false);
 
-    // first check if the user is already logged in
-    // by checking if there's a valid token on component mount
     useEffect(() => {
-        const checkToken = async () => {
-
-            if (!token) {
-                setLoading(false);  // No token, allow the user to log in or register
-                return;
-            }
-
-            try {
-                // if token found, make a request to validate it
-                const response = await apiClient.post('/auth/token', { token });
-
-                if (response.status === 200) {
-                    setMessage('');
-                    // Token is valid, redirect to /dashboard
-                    router.push('/dashboard');
-                }
-            } catch (err) {
-                // Token is invalid or error occurred, show login form
-                setMessageType('warning');
-                setMessage('Invalid or expired token, please log in or register.');
-                setLoading(false);
-            }
-        };
-
-        checkToken();
-    }, [router, token]);
-
-    useEffect(() => {
-        if(justRegistered)
-        {
+        if (justRegistered) {
             setMessageType('success');
             setMessage('Thank you for registering! Please verify your account.');
         }
     }, [justRegistered]);
-
-
-    if (loading) {
-        // show a loading indicator while checking the token
-        return (
-            <Container fluid className="justify-content-md-center">
-                <Spinner animation="grow" />
-            </Container>
-        );
-    }
 
     return (
         <AuthContext.Provider value={{ message, setMessage, messageType, setMessageType, setJustRegistered }}>
@@ -79,7 +30,7 @@ export default function DashboardLayout({ children }) {
                     </Col>
                     <Col className="form-section" xs={12} md={5} xl={4} >
                         <main className="form-card">
-                            {message && <Alert variant={messageType} className='mt-4' style={{textAlign: "center"}}>{message}</Alert>}
+                            {message && <Alert variant={messageType} className='mt-4' style={{ textAlign: "center" }}>{message}</Alert>}
                             {children}
                         </main>
                     </Col>

--- a/src/app/(auth)/login/page.js
+++ b/src/app/(auth)/login/page.js
@@ -1,11 +1,10 @@
 'use client';
 
 import '@/app/(auth)/auth.css';
-import { Button, Card, Container, Form } from "react-bootstrap";
+import { Button, Card, Container, Form, Spinner } from "react-bootstrap";
 import apiClient from "@utils/api";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { setCookie } from "nookies";
 import { useAuth } from "../layout";
 import { Envelope, Key, PersonPlusFill, PersonVcardFill } from 'react-bootstrap-icons';
 import { useUser } from '@/utils/UserContext';
@@ -16,65 +15,101 @@ export default function LoginPage() {
     const [password, setPassword] = useState('');
     const { setMessage, setMessageType } = useAuth();
     const [submitted, setSubmitted] = useState(false);
+    // const [loading, setLoading] = useState(true);
     const userContext = useUser();
+
+    // useEffect(() => {
+    //     const checkSession = async () => {
+    //         try {
+    //             const response = await apiClient.get('/auth/session');
+    //             if (response.status === 200 && response.data.isValid) 
+    //             {
+    //                 router.replace('/dashboard');
+    //             }
+    //         } catch (error) 
+    //         {
+    //             if(error.status === 401)
+    //             {
+    //                 // means the session is invalid, need to log in again
+    //                 setLoading(false);
+    //             }
+    //             else
+    //             {
+    //                 console.error('Unexpected error:', error.response?.data?.message || 'Unexpected error');
+    //                 setMessageType('danger');
+    //                 setMessage('Unexpected server error/response');
+    //             }
+    //         }
+    //     };
+
+    //     checkSession();
+    // }, [router, setMessage, setMessageType]);
 
     const handleSubmit = async (e) => {
         e.preventDefault();
-        
+
         setSubmitted(true);
 
-        try {
-            const response = await apiClient.post('/auth/login', { email, password });
+        apiClient.post('/auth/login', { email, password })
+            .then(_response => {
+                setMessageType('success');
+                setMessage('Success! Redirecting to dashboard...');
 
-            // Save the token in a cookie
-            setCookie(null, 'token', response.data.token, {
-                maxAge: 120 * 60 * 60, // 120 minutes
-                path: '/', // Accessible on all pages
+                // redirect to the dashboard page
+                router.push('/dashboard');
+            })
+            .catch(err => {
+                if (err.status === 403) {
+                    // handle case when the account exists but isn't verified yet
+                    // redirect to the verify page
+                    userContext.setUser({ email });
+                    router.push('/verify');
+                }
+                else if (err.status === 400) {
+                    console.error('Login error:', err.response?.data?.message || 'Login failed');
+                    setMessageType('warning');
+                    setMessage('Invalid email or password!');
+                    setSubmitted(false);
+                }
+                else {
+                    // Unexpected error
+                    console.error('Login error:', err.response?.data?.message || 'Login failed');
+                    setMessageType('danger');
+                    setMessage('Unexpected server error/response');
+                    setSubmitted(false);
+                }
             });
-
-            setMessageType('success');
-            setMessage('Success! Redirecting to dashboard...');
-
-            // redirect to the dashboard page
-            router.push('/dashboard');
-        }
-        catch (err) {
-            if(err.status === 403)
-            {
-                // handle case when the account exists but isn't verified yet
-                // redirect to the verify page
-                userContext.setUser({email});
-                router.push('/verify');
-            }
-            else if(err.status === 400)
-            {
-                console.error('Login error:', err.response?.data?.message || 'Login failed');
-                setMessageType('warning');
-                setMessage('Invalid email or password!');
-                setSubmitted(false);
-            }
-            else
-            {
-                // Unexpected error
-                console.error('Login error:', err.response?.data?.message || 'Login failed');
-                setMessageType('danger');
-                setMessage('Unexpected server error/response');
-                setSubmitted(false);
-            }
-        }
     };
+
+    // if(loading)
+    // {
+    //     return (
+    //         <Container className="mt-4">
+    //             <Card className="form">
+    //                 <Card.Header>
+    //                     <PersonVcardFill size="22" color="black" /> {' '}
+    //                     Checking your session...
+    //                 </Card.Header>
+    //                 <Card.Body>
+    //                     <Spinner size="48" color="black" animation="grow" />
+    //                     <p>Please wait...</p>
+    //                 </Card.Body>
+    //             </Card>
+    //         </Container>
+    //     );
+    // }
 
     return (
         <Container className="mt-4">
             <Card className="form">
                 <Card.Header>
-                    <PersonVcardFill size="22" color="black"/> {' '}
+                    <PersonVcardFill size="22" color="black" /> {' '}
                     Sign in to your account!
                 </Card.Header>
                 <Card.Body>
                     <Form onSubmit={handleSubmit}>
                         <Form.Group className="mb-3" controlId="formEmail">
-                            <Form.Label><Envelope size="18"/> {' '} Email address</Form.Label>
+                            <Form.Label><Envelope size="18" /> {' '} Email address</Form.Label>
                             <Form.Control type="email" placeholder="..." value={email} onChange={(e) => setEmail(e.target.value)} required />
                             <Form.Text className="text-muted">
                                 The email address you used to sign up.
@@ -82,7 +117,7 @@ export default function LoginPage() {
                         </Form.Group>
 
                         <Form.Group className="mb-3" controlId="formPassword">
-                            <Form.Label><Key size="18"/>{' '} Password</Form.Label>
+                            <Form.Label><Key size="18" />{' '} Password</Form.Label>
                             <Form.Control type="password" placeholder="..." value={password} onChange={(e) => setPassword(e.target.value)} required />
                         </Form.Group>
 
@@ -92,11 +127,11 @@ export default function LoginPage() {
                     </Form>
                 </Card.Body>
                 <Card.Footer>
-                    <PersonPlusFill size="22" color="black" style={{marginRight: "4px"}} /> {' '}
+                    <PersonPlusFill size="22" color="black" style={{ marginRight: "4px" }} /> {' '}
                     Don&apos;t have an account? {' '}
-                    <Card.Link 
-                        style={{cursor: "pointer", textDecoration: "none"}} 
-                        onClick={()=> {router.push("/register")}}
+                    <Card.Link
+                        style={{ cursor: "pointer", textDecoration: "none" }}
+                        onClick={() => { router.push("/register") }}
                     >
                         Register!
                     </Card.Link>

--- a/src/app/(auth)/login/page.js
+++ b/src/app/(auth)/login/page.js
@@ -1,9 +1,9 @@
 'use client';
 
 import '@/app/(auth)/auth.css';
-import { Button, Card, Container, Form, Spinner } from "react-bootstrap";
+import { Button, Card, Container, Form } from "react-bootstrap";
 import apiClient from "@utils/api";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "../layout";
 import { Envelope, Key, PersonPlusFill, PersonVcardFill } from 'react-bootstrap-icons';
@@ -15,35 +15,8 @@ export default function LoginPage() {
     const [password, setPassword] = useState('');
     const { setMessage, setMessageType } = useAuth();
     const [submitted, setSubmitted] = useState(false);
-    // const [loading, setLoading] = useState(true);
     const userContext = useUser();
 
-    // useEffect(() => {
-    //     const checkSession = async () => {
-    //         try {
-    //             const response = await apiClient.get('/auth/session');
-    //             if (response.status === 200 && response.data.isValid) 
-    //             {
-    //                 router.replace('/dashboard');
-    //             }
-    //         } catch (error) 
-    //         {
-    //             if(error.status === 401)
-    //             {
-    //                 // means the session is invalid, need to log in again
-    //                 setLoading(false);
-    //             }
-    //             else
-    //             {
-    //                 console.error('Unexpected error:', error.response?.data?.message || 'Unexpected error');
-    //                 setMessageType('danger');
-    //                 setMessage('Unexpected server error/response');
-    //             }
-    //         }
-    //     };
-
-    //     checkSession();
-    // }, [router, setMessage, setMessageType]);
 
     const handleSubmit = async (e) => {
         e.preventDefault();
@@ -54,7 +27,7 @@ export default function LoginPage() {
             .then(_response => {
                 setMessageType('success');
                 setMessage('Success! Redirecting to dashboard...');
-
+                userContext.refetch();
                 // redirect to the dashboard page
                 router.push('/dashboard');
             })
@@ -81,23 +54,6 @@ export default function LoginPage() {
             });
     };
 
-    // if(loading)
-    // {
-    //     return (
-    //         <Container className="mt-4">
-    //             <Card className="form">
-    //                 <Card.Header>
-    //                     <PersonVcardFill size="22" color="black" /> {' '}
-    //                     Checking your session...
-    //                 </Card.Header>
-    //                 <Card.Body>
-    //                     <Spinner size="48" color="black" animation="grow" />
-    //                     <p>Please wait...</p>
-    //                 </Card.Body>
-    //             </Card>
-    //         </Container>
-    //     );
-    // }
 
     return (
         <Container className="mt-4">

--- a/src/app/(auth)/register/page.js
+++ b/src/app/(auth)/register/page.js
@@ -26,26 +26,24 @@ export default function RegisterPage() {
 
         setSubmitted(true);
 
-        try {
-            const response = await apiClient.post('/auth/register', { email, password, phone, name, balance: balance * 100 });
-
+        await apiClient.post('/auth/register',
+             { email, password, phone, name, balance: balance * 100 })
+        .then(_response => {
             //save incomplete user object to context, to be used temporarily in verification page
-            const userForVerification = {email, name, phone};
-            userContext.setUser(userForVerification);
-
-            console.log("user object after setting incomplete data: ", userContext.user);
+            const userForVerification = { email, name, phone };
+            userContext.setIncompleteUser(userForVerification);
 
             setMessageType('success');
             setMessage('Success! redirecting to verification...');
             setJustRegistered(true);
             // redirect to the verification page
             router.push('/verify');
-        }
-        catch (err) {
+        })
+        .catch(_err => {
             setMessageType('warning');
             setMessage('Registration failed! Please make sure that the data you provided is valid.');
             setSubmitted(false);
-        }
+        });
     };
 
     return (

--- a/src/app/(auth)/verify/page.js
+++ b/src/app/(auth)/verify/page.js
@@ -45,12 +45,15 @@ export default function VerifyPage() {
 
         setSubmitted(true);
 
-        const { email } = userContext.user;
+        console.log("[VerifyPage] UserContext:", userContext);
+
+        const { email } = userContext.incompleteUser;
 
         apiClient.post('/auth/verify', { email, verificationCode })
             .then(_response => {
                 setMessageType('success');
                 setMessage('Account Verified! Redirecting to login...');
+                userContext.setIncompleteUser(null); // Clear the incomplete user data
                 router.push('/login');  // Redirect to the login page
             })
             .catch(err => {

--- a/src/app/admin/layout.js
+++ b/src/app/admin/layout.js
@@ -1,31 +1,6 @@
-'use client';
-
-import { useUser } from "@/utils/UserContext";
-import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
-import { Container, Row, Spinner } from "react-bootstrap";
+import { Container, Row } from "react-bootstrap";
 
 export default function AdminDashboardLayout({ children }) {
-    const userContext = useUser();
-    const router = useRouter();
-    const [permitted, setPermitted] = useState(false);
-
-    useEffect(() => {
-        if (!userContext.valid) {
-            router.push('/login');
-        } else if (userContext.user?.role !== 'admin') {
-            router.push('/dashboard');
-        } else {
-            setPermitted(true);
-        }
-    }, [userContext, router]);
-
-
-    if(!permitted)
-    {
-        return <Spinner size="48" color="black" animation="grow" />
-    }
-
     return (
         <>
             <Container fluid className="admin-dashboard-layout">

--- a/src/app/admin/layout.js
+++ b/src/app/admin/layout.js
@@ -2,34 +2,28 @@
 
 import { useUser } from "@/utils/UserContext";
 import { useRouter } from "next/navigation";
-import { parseCookies } from "nookies";
 import { useEffect, useState } from "react";
 import { Container, Row, Spinner } from "react-bootstrap";
-
 
 export default function AdminDashboardLayout({ children }) {
     const userContext = useUser();
     const router = useRouter();
     const [permitted, setPermitted] = useState(false);
-    const {token} = parseCookies();
 
     useEffect(() => {
-        if(!token)
-        {
-            router.replace('/login');
-        }
-        else if (!userContext || !userContext.user || userContext.user.role !== 'admin') {
-            router.replace('/dashboard');
-        }
-        else
-        {
+        if (!userContext.valid) {
+            router.push('/login');
+        } else if (userContext.user?.role !== 'admin') {
+            router.push('/dashboard');
+        } else {
             setPermitted(true);
         }
-    }, [userContext, router, token]);
+    }, [userContext, router]);
+
 
     if(!permitted)
     {
-        return <Spinner animation="grow" size="48"/>;
+        return <Spinner size="48" color="black" animation="grow" />
     }
 
     return (

--- a/src/app/admin/page.js
+++ b/src/app/admin/page.js
@@ -1,12 +1,14 @@
 'use client';
 
+import { useRouter } from "next/navigation";
 import { Button } from "react-bootstrap";
 
 export default function AdminPage() {
+    const router = useRouter();
     return (
         <div>
             <h1>Admin Page</h1>
-            <Button href="/admin/users" variant="primary">Manage Users</Button>
+            <Button variant="primary" onClick={() => router.push('/admin/users')}>Manage Users</Button>
         </div>
     );
 }

--- a/src/app/api/usersApi.js
+++ b/src/app/api/usersApi.js
@@ -1,30 +1,24 @@
 import apiClient from "@/utils/api";
 
 
-export const fetchContacts = async (userId, token) => {
-    try
-    {
+export const fetchContacts = async (userId) => {
+    try {
         const response = await apiClient.get(`/users/${userId}/contacts`, {
-            headers: {
-                Authorization: `Bearer ${token}`,
-            }
+            withCredentials: true,
         });
-    
+
         return response.data.contacts; // Return only the contacts array
     }
-    catch(error)
-    {
-        throw new Error(`Failed to fetch contacts: ${error.response?.data?.message || error.message}`);    
+    catch (error) {
+        throw new Error(`Failed to fetch contacts: ${error.response?.data?.message || error.message}`);
     }
 };
 
-export const deleteContact = async (userId, contactId, token) => {
+export const deleteContact = async (userId, contactId) => {
     try
     {
         const response = await apiClient.delete(`/users/${userId}/contacts/${contactId}`, {
-            headers: {
-                Authorization: `Bearer ${token}`,
-            }
+            withCredentials: true,
         });
     
         return response.data;
@@ -35,13 +29,11 @@ export const deleteContact = async (userId, contactId, token) => {
     }
 };
 
-export const fetchUsers = async (token) => {
+export const fetchUsers = async () => {
     try
     {
         const response = await apiClient.get('/users', {
-            headers: {
-                Authorization: `Bearer ${token}`,
-            }
+            withCredentials: true,
         });
     
         return response.data; // Return only the users array

--- a/src/app/api/usersApi.js
+++ b/src/app/api/usersApi.js
@@ -29,6 +29,14 @@ export const deleteContact = async (userId, contactId) => {
     }
 };
 
+export const fetchCurrentUser = async () => {
+    const response = await apiClient.get(`/users/me`, { withCredentials: true });
+    if (!response.data?.user) {
+        throw new Error("User not authenticated");
+    }
+    return response.data.user;
+};
+
 export const fetchUsers = async () => {
     try
     {

--- a/src/app/dashboard/page.js
+++ b/src/app/dashboard/page.js
@@ -5,42 +5,32 @@ import TransactionList from "@/components/TransactionList";
 import UserCard from "@/components/UserCard";
 import apiClient from "@/utils/api";
 import { useUser } from "@/utils/UserContext";
-import { parseCookies } from "nookies";
 import { useEffect, useState } from "react";
 import { Col, Collapse, Container, Row } from "react-bootstrap";
 
 
 export default function DashboardPage() {
-    const { token } = parseCookies();
     const userContext = useUser();
     const [showSendMoneyModal, setShowSendMoneyModal] = useState(false);
     const [openTransactions, setOpenTransactions] = useState(false);
 
     useEffect(() => {
         const fetchUserDetails = async () => {
-            if (!token) {
-                console.log("NO TOKEN!");
-                userContext.handleLogout();
-                return;
-            }
-
             // Prevent fetching if user is already loaded
             if (userContext.valid) return;
 
-
             apiClient.get(`/users/me`, {
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                },
+                withCredentials: true,
             })
                 .then(response => {
                     if (response.data && response.data.user) {
+                        console.log("User data fetched successfully");
                         userContext.setUser(response.data.user);
                         userContext.setValid(true);
                     } else {
                         // If user data is invalid or missing
                         console.error("Invalid user data");
-                        handleLogout();
+                        userContext.handleLogout();
                     }
                 })
                 .catch(err => {

--- a/src/app/dashboard/page.js
+++ b/src/app/dashboard/page.js
@@ -3,9 +3,8 @@
 import SendMoneyPopup from "@/components/SendMoneyPopup";
 import TransactionList from "@/components/TransactionList";
 import UserCard from "@/components/UserCard";
-import apiClient from "@/utils/api";
 import { useUser } from "@/utils/UserContext";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Col, Collapse, Container, Row } from "react-bootstrap";
 
 
@@ -14,44 +13,18 @@ export default function DashboardPage() {
     const [showSendMoneyModal, setShowSendMoneyModal] = useState(false);
     const [openTransactions, setOpenTransactions] = useState(false);
 
-    useEffect(() => {
-        const fetchUserDetails = async () => {
-            // Prevent fetching if user is already loaded
-            if (userContext.valid) return;
-
-            apiClient.get(`/users/me`, {
-                withCredentials: true,
-            })
-                .then(response => {
-                    if (response.data && response.data.user) {
-                        console.log("User data fetched successfully");
-                        userContext.setUser(response.data.user);
-                        userContext.setValid(true);
-                    } else {
-                        // If user data is invalid or missing
-                        console.error("Invalid user data");
-                        userContext.handleLogout();
-                    }
-                })
-                .catch(err => {
-                    console.error("Error fetching user details:", err);
-                    userContext.handleLogout();
-                })
-
-        };
-
-        fetchUserDetails();
-    });
-
-    const userEmail = userContext.user?.email;
+    const userEmail = userContext?.user?.email || "";
 
     return (
         <Container>
             <Row >
                 <Col className="d-flex justify-content-md-center align-items-center">
-                    <UserCard 
-                        onPrimaryClick={() => setShowSendMoneyModal(true)} 
-                        onSecondaryClick={() => setOpenTransactions(!openTransactions)} 
+                    <UserCard
+                        onPrimaryClick={() => {
+                            console.log("Modal open triggered");
+                            setShowSendMoneyModal(true);
+                        }}
+                        onSecondaryClick={() => setOpenTransactions(!openTransactions)}
                         primaryText="Send Money!"
                         secondaryText={`${openTransactions ? 'Hide' : 'Show'} History`}
                     />
@@ -67,7 +40,13 @@ export default function DashboardPage() {
                 </Col>
             </Row>
 
-            <SendMoneyPopup show={showSendMoneyModal} onHide={() => setShowSendMoneyModal(false)}/>
+            <SendMoneyPopup
+                show={showSendMoneyModal}
+                onHide={() => {
+                    console.log("Modal close triggered");
+                    setShowSendMoneyModal(false);
+                }}
+            />
         </Container>
     );
 }

--- a/src/components/SendMoneyPopup.js
+++ b/src/components/SendMoneyPopup.js
@@ -80,7 +80,7 @@ export default function SendMoneyPopup({ show, onHide }) {
             });
     };
 
-    if (!userContext.valid) {
+    if (!userContext.user) {
         return;
     }
 
@@ -111,8 +111,8 @@ export default function SendMoneyPopup({ show, onHide }) {
                                 />
                             </Form.Group>
 
-                            <small style={{fontSize: '0.7rem', letterSpacing: '-0.3px'}}>Saved contacts:</small>
-                            <ContactRow userId={userContext.user._id} onContactChoice={handleContactChoice}/>
+                            <small style={{ fontSize: '0.7rem', letterSpacing: '-0.3px' }}>Saved contacts:</small>
+                            <ContactRow userId={userContext.user._id} onContactChoice={handleContactChoice} />
 
                             <Form.Group
                                 className="mb-3 mt-3"
@@ -128,14 +128,14 @@ export default function SendMoneyPopup({ show, onHide }) {
                                     required
                                 />
                                 {userContext.valid && (<span>
-                                <Badge className="mt-2" bg="warning" text="dark">Maximum amount you can send: ${userContext.user.balance / 100}</Badge>
+                                    <Badge className="mt-2" bg="warning" text="dark">Maximum amount you can send: ${userContext.user.balance / 100}</Badge>
                                 </span>)}
                             </Form.Group>
                         </Form>
                     </>
                 }
                 {success &&
-                    <TransactionSuccess transaction={transaction}/>
+                    <TransactionSuccess transaction={transaction} />
                 }
 
                 {error &&
@@ -144,7 +144,7 @@ export default function SendMoneyPopup({ show, onHide }) {
             </Modal.Body>
             <Modal.Footer>
                 <Button variant={success ? "primary" : "secondary"} onClick={handleHide} disabled={!success && submitted}>
-                    {success ? <CheckCircle size="22" color="white" /> : <XCircle size="22" color="white" /> } {' '}
+                    {success ? <CheckCircle size="22" color="white" /> : <XCircle size="22" color="white" />} {' '}
                     {success ? "Done" : "Cancel"}
                 </Button>
                 {!success &&

--- a/src/components/TopNav.js
+++ b/src/components/TopNav.js
@@ -3,28 +3,42 @@
 import { Jockey_One } from 'next/font/google';
 import '@/styles/TopNav.css';
 import { useUser } from '@/utils/UserContext';
-import { useEffect, useState } from 'react';
-import { Button, Container, Navbar, Stack } from "react-bootstrap";
+import { Button, Container, Navbar, Spinner, Stack } from "react-bootstrap";
 import { BoxArrowRight, PersonLock } from 'react-bootstrap-icons';
 import Image from 'next/image';
-import { usePathname, useRouter } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 
 const jockeyOne = Jockey_One({ subsets: ['latin'], weight: '400' });
 
 export default function TopNav() {
-    const userContext = useUser();
+    const { user, role, isLoading, isError, handleLogout } = useUser();
     const router = useRouter();
-    const pathname = usePathname();
-    const [isLoggedIn, setIsLoggedIn] = useState(false);
-    const [isAdmin, setIsAdmin] = useState(false);
 
-    useEffect(() => {
-        const user = userContext.user;
-        setIsLoggedIn(pathname !== '/login' && user != null && user.name !== '');
-        setIsAdmin(pathname !== '/login' && user != null && user.role === 'admin');
-    }, [userContext.user, pathname]); // React to both user changes and route changes
+    // placeholder for when there's an error fetching the user data
+    if (isError) {
+        return (
+            <Navbar className="top-nav" sticky="top">
+                <Container>
+                    <Navbar.Brand href='/dashboard' className='logo'>
+                        <Image
+                            src='/images/logo-nav.webp'
+                            alt='GoldFront Bank logo'
+                            width={34}
+                            height={34}
+                            style={{ verticalAlign: 'middle', borderRadius: '10px' }}
+                        /> {' '}
+                        <span className={`nav-title ${jockeyOne.className}`} style={{ verticalAlign: 'middle' }}>GoldFront Bank</span>
+                    </Navbar.Brand>
 
-
+                    <div className="ms-auto d-flex align-items-center">
+                    </div>
+                </Container>
+            </Navbar>
+        );
+    }
+    
+    const isLoggedIn = Boolean(user);
+    const isAdmin = role === "admin";
 
     return (
         <Navbar className="top-nav" sticky="top">
@@ -36,25 +50,47 @@ export default function TopNav() {
                         width={34}
                         height={34}
                         style={{ verticalAlign: 'middle', borderRadius: '10px' }}
-                    /> {' '}
-                    <span className={`nav-title ${jockeyOne.className}`} style={{ verticalAlign: 'middle' }} >GoldFront Bank</span>
+                    />{' '}
+                    <span className={`nav-title ${jockeyOne.className}`} style={{ verticalAlign: 'middle' }}>
+                        GoldFront Bank
+                    </span>
                 </Navbar.Brand>
 
                 <div className="ms-auto d-flex align-items-center">
                     <Stack direction="horizontal" gap={2}>
-                        {isAdmin && (
-                            <Navbar.Text style={{ color: "black" }}>
-                                <Button className="btn-admin" variant='light' onClick={() => { router.push('/admin') }} ><PersonLock size="16" color='black' /> Admin</Button>
-                            </Navbar.Text>
-                        )}
-
-                        {isLoggedIn && userContext.user &&
-                            (
-                                <Navbar.Text style={{ color: "white" }}>
-                                    <Button className="btn-logout" variant='dark' onClick={userContext.handleLogout} ><BoxArrowRight size="16" color='white' /> Sign out</Button>
+                        {/* Admin Button */}
+                        {isLoading ? (
+                            <div style={{ visibility: "hidden" }}>
+                                <Button className="btn-admin" variant='light'>
+                                    <PersonLock size="16" /> Admin
+                                </Button>
+                            </div>
+                        ) : (
+                            isAdmin && (
+                                <Navbar.Text>
+                                    <Button className="btn-admin" variant='light' onClick={() => { router.push('/admin') }}>
+                                        <PersonLock size="16" color='black' /> Admin
+                                    </Button>
                                 </Navbar.Text>
                             )
-                        }
+                        )}
+
+                        {/* Logout Button */}
+                        {isLoading ? (
+                            <div style={{ visibility: "hidden" }}>
+                                <Button className="btn-logout" variant='dark'>
+                                    <BoxArrowRight size="16" /> Sign out
+                                </Button>
+                            </div>
+                        ) : (
+                            isLoggedIn && (
+                                <Navbar.Text>
+                                    <Button className="btn-logout" variant='dark' onClick={handleLogout}>
+                                        <BoxArrowRight size="16" color='white' /> Sign out
+                                    </Button>
+                                </Navbar.Text>
+                            )
+                        )}
                     </Stack>
                 </div>
             </Container>

--- a/src/components/TransactionList.js
+++ b/src/components/TransactionList.js
@@ -18,7 +18,7 @@ export default function TransactionList({userEmail}){
     const { data: transactions, isLoading, error } = useQuery({
         queryKey: ['transactions', userEmail],
         queryFn: () => userEmail ? ( userEmail === userContext.user.email ? fetchMyTransactions(token) : fetchUserTransactions(userEmail, token)) : Promise.reject('User email is null'),
-        enabled: !!userEmail && !!token, // Only run query if userEmail is truthy
+        enabled: !!userEmail, // Only run query if userEmail is truthy
         staleTime: 5 * 60 * 1000, // Optional: Cache duration
     });
 

--- a/src/components/UserCard.js
+++ b/src/components/UserCard.js
@@ -8,8 +8,27 @@ import { Clipboard2Data, SendPlusFill } from 'react-bootstrap-icons';
 export default function UserCard({ onPrimaryClick, primaryText, onSecondaryClick, secondaryText }) {
     const userContext = useUser();
 
-    if (!userContext.valid) {
-        return <Spinner animation="grow" variant="light" role="status" />
+    if (userContext.isLoading || !userContext.user) {
+        return (
+            <Card className='user-card'>
+                <Card.Body>
+                    <Container fluid>
+                        <Row>
+                            <Col xs="7">
+                                <Row>
+                                    <h2 className='card-title'>Loading...</h2>
+                                </Row>
+                                <hr style={{ marginTop: '0', marginRight: '1.15rem', color: 'grey' }} />
+                                <Row className='mt-4'>
+                                    <Spinner animation='border' role='status' />
+                                </Row>
+                            </Col>
+                            <Col xs="5" className='safe-back' />
+                        </Row>
+                    </Container>
+                </Card.Body>
+            </Card>
+        );
     }
 
     return (
@@ -23,13 +42,17 @@ export default function UserCard({ onPrimaryClick, primaryText, onSecondaryClick
                                 <p style={{ fontSize: '0.65rem', fontWeight: '500', marginTop: '0.6rem', marginBottom: '0.1rem' }}>Current balance</p>
                                 <span className="balance">$ {userContext.user.balance / 100}</span>
                             </Row>
-                            <hr style={{marginTop: '0', marginRight: '1.15rem', color: 'grey'}}/>
+                            <hr style={{ marginTop: '0', marginRight: '1.15rem', color: 'grey' }} />
                             <Row className='mt-4'>
                                 <Stack direction='horizontal' gap={2}>
-                                    <Button 
-                                        variant='primary' 
-                                        className='menu-btn send-btn' 
-                                        onClick={onPrimaryClick}
+                                    <Button
+                                        variant='primary'
+                                        className='menu-btn send-btn'
+                                        onClick={() => {
+                                            console.log("Primary button clicked");
+                                            console.log("[UserCard] UserContext:", userContext);
+                                            onPrimaryClick();
+                                        }}
                                     >
                                         <SendPlusFill size={24} color="white" />{' '}
                                         <span style={{ verticalAlign: 'middle' }}>{primaryText}</span>
@@ -41,12 +64,12 @@ export default function UserCard({ onPrimaryClick, primaryText, onSecondaryClick
                                         aria-controls='transactions-collapse'
                                     >
                                         <Clipboard2Data size={24} color="white" />{' '}
-                                        <span style={{verticalAlign: 'middle'}}>{secondaryText}</span>
+                                        <span style={{ verticalAlign: 'middle' }}>{secondaryText}</span>
                                     </Button>
                                 </Stack>
                             </Row>
                         </Col>
-                        <Col xs="5" className='safe-back'/>
+                        <Col xs="5" className='safe-back' />
                     </Row>
                 </Container>
             </Card.Body>

--- a/src/components/UserList/UserList.js
+++ b/src/components/UserList/UserList.js
@@ -18,7 +18,7 @@ export default function UserList() {
     const { data: users, isLoading, error } = useQuery({
         queryKey: ['users'],
         queryFn: () => fetchUsers(token),
-        enabled: !!token,
+        enabled: true,
         staleTime: 5 * 60 * 1000,
     });
 

--- a/src/components/contacts/ContactRow.js
+++ b/src/components/contacts/ContactRow.js
@@ -13,7 +13,7 @@ export default function ContactRow({ userId, onContactChoice })
     const { data: contacts, isLoading, error } = useQuery({
         queryKey: ['contacts', userId],
         queryFn: () => userId ? fetchContacts(userId, token) : Promise.reject('User id is null'),
-        enabled: !!userId && !!token, // Only run query if userId is truthy
+        enabled: !!userId, // Only run query if userId is truthy
         staleTime: 15 * 60 * 1000, // Optional: Cache duration
     });
 

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -4,9 +4,11 @@ import apiClient from '@/utils/api';
 export async function middleware(req) {
     const url = req.nextUrl.clone();
     const isValid = req.cookies.get('session_valid')?.value === 'true';
-    
+    const userRole = req.cookies.get('session_role')?.value;
+
     console.log("[Middleware] ", "session_valid: ", req.cookies.get('session_valid'));
     console.log("[Middleware] ", "IsValid: ", isValid);
+    console.log("[Middleware] ", "UserRole: ", userRole);
 
 
     if (url.pathname === '/login' || url.pathname === '/register') {
@@ -18,11 +20,19 @@ export async function middleware(req) {
     }
 
     if (isValid) {
+
+        // Check if accessing an admin route and if the user has the 'admin' role
+        if (url.pathname.startsWith('/admin') && userRole !== 'admin') {
+            console.log("[Middleware] ", "User does not have admin privileges. Redirecting to /dashboard.");
+            return NextResponse.redirect(new URL('/dashboard', req.url));
+        }
+
         console.log("[Middleware] ", "Session valid. Allowing access.");
         return NextResponse.next();
     }
 
     try {
+        console.log("[Middleware] ", "Checking session validity with the server...");
         const response = await apiClient.get('/auth/session', {
             headers: { 'Cookie': req.headers.get('cookie') },
         });
@@ -31,6 +41,14 @@ export async function middleware(req) {
             console.log("[Middleware] ", "Session valid. Setting validation cookie.");
             const res = NextResponse.next();
             res.cookies.set('session_valid', 'true', { maxAge: 300, httpOnly: true });
+            res.cookies.set('session_role', response.data.role, { maxAge: 300, httpOnly: true });
+            
+            // Check if accessing an admin route and if the user has the 'admin' role
+            if (url.pathname.startsWith('/admin') && response.data.role !== 'admin') {
+                console.log("[Middleware] ", "User does not have admin privileges. Redirecting to /dashboard.");
+                return NextResponse.redirect(new URL('/dashboard', req.url));
+            }
+            
             return res;
         }
     } catch (error) {

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server';
+import apiClient from '@/utils/api';
+
+export async function middleware(req) {
+    const url = req.nextUrl.clone();
+    const isValid = req.cookies.get('session_valid')?.value === 'true';
+    
+    console.log("[Middleware] ", "session_valid: ", req.cookies.get('session_valid'));
+    console.log("[Middleware] ", "IsValid: ", isValid);
+
+
+    if (url.pathname === '/login' || url.pathname === '/register') {
+        if (isValid) {
+            console.log("[Middleware] ", "Session valid. Redirecting to /dashboard.");
+            return NextResponse.redirect(new URL('/dashboard', req.url));
+        }
+        return NextResponse.next();
+    }
+
+    if (isValid) {
+        console.log("[Middleware] ", "Session valid. Allowing access.");
+        return NextResponse.next();
+    }
+
+    try {
+        const response = await apiClient.get('/auth/session', {
+            headers: { 'Cookie': req.headers.get('cookie') },
+        });
+
+        if (response.status === 200 && response.data.isValid) {
+            console.log("[Middleware] ", "Session valid. Setting validation cookie.");
+            const res = NextResponse.next();
+            res.cookies.set('session_valid', 'true', { maxAge: 300, httpOnly: true });
+            return res;
+        }
+    } catch (error) {
+        console.log("[Middleware] ", "Session invalid. Redirecting to /login.");
+    }
+
+    return NextResponse.redirect(new URL('/login', req.url));
+}
+
+export const config = {
+    matcher: ['/login', '/register', '/admin/:path*', '/dashboard/:path*'],
+};

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -6,14 +6,14 @@ export async function middleware(req) {
     const isValid = req.cookies.get('session_valid')?.value === 'true';
     const userRole = req.cookies.get('session_role')?.value;
 
-    console.log("[Middleware] ", "session_valid: ", req.cookies.get('session_valid'));
-    console.log("[Middleware] ", "IsValid: ", isValid);
-    console.log("[Middleware] ", "UserRole: ", userRole);
+    console.log("[Middleware]", "session_valid: ", req.cookies.get('session_valid'));
+    console.log("[Middleware]", "IsValid: ", isValid);
+    console.log("[Middleware]", "UserRole: ", userRole);
 
 
-    if (url.pathname === '/login' || url.pathname === '/register') {
+    if (url.pathname === '/login' || url.pathname === '/register' || url.pathname === '/verify') {
         if (isValid) {
-            console.log("[Middleware] ", "Session valid. Redirecting to /dashboard.");
+            console.log("[Middleware]", "Session valid. Redirecting to /dashboard.");
             return NextResponse.redirect(new URL('/dashboard', req.url));
         }
         return NextResponse.next();
@@ -23,41 +23,41 @@ export async function middleware(req) {
 
         // Check if accessing an admin route and if the user has the 'admin' role
         if (url.pathname.startsWith('/admin') && userRole !== 'admin') {
-            console.log("[Middleware] ", "User does not have admin privileges. Redirecting to /dashboard.");
+            console.log("[Middleware]", "User does not have admin privileges. Redirecting to /dashboard.");
             return NextResponse.redirect(new URL('/dashboard', req.url));
         }
 
-        console.log("[Middleware] ", "Session valid. Allowing access.");
+        console.log("[Middleware]", "Session valid. Allowing access.");
         return NextResponse.next();
     }
 
     try {
-        console.log("[Middleware] ", "Checking session validity with the server...");
+        console.log("[Middleware]", "Checking session validity with the server...");
         const response = await apiClient.get('/auth/session', {
             headers: { 'Cookie': req.headers.get('cookie') },
         });
 
         if (response.status === 200 && response.data.isValid) {
-            console.log("[Middleware] ", "Session valid. Setting validation cookie.");
+            console.log("[Middleware]", "Session valid. Setting validation cookie.");
             const res = NextResponse.next();
             res.cookies.set('session_valid', 'true', { maxAge: 300, httpOnly: true });
             res.cookies.set('session_role', response.data.role, { maxAge: 300, httpOnly: true });
             
             // Check if accessing an admin route and if the user has the 'admin' role
             if (url.pathname.startsWith('/admin') && response.data.role !== 'admin') {
-                console.log("[Middleware] ", "User does not have admin privileges. Redirecting to /dashboard.");
+                console.log("[Middleware]", "User does not have admin privileges. Redirecting to /dashboard.");
                 return NextResponse.redirect(new URL('/dashboard', req.url));
             }
             
             return res;
         }
     } catch (error) {
-        console.log("[Middleware] ", "Session invalid. Redirecting to /login.");
+        console.log("[Middleware]", "Session invalid. Redirecting to /login.");
     }
 
     return NextResponse.redirect(new URL('/login', req.url));
 }
 
 export const config = {
-    matcher: ['/login', '/register', '/admin/:path*', '/dashboard/:path*'],
+    matcher: ['/login', '/register', '/verify', '/admin/:path*', '/dashboard/:path*'],
 };

--- a/src/utils/UserContext.js
+++ b/src/utils/UserContext.js
@@ -1,34 +1,15 @@
 'use client';
 
 import { useQueryClient } from "@tanstack/react-query";
-import { useRouter } from "next/navigation";
-import { createContext, useContext, useState, useEffect } from "react";
+import { createContext, useContext, useEffect, useState } from "react";
 import { globalLogout } from "./logout";
 
 const userContext = createContext();
 
 export const UserProvider = ({ children }) => {
-    const router = useRouter();
     const [valid, setValid] = useState(false);
     const queryClient = useQueryClient(); // Access the QueryClient
-
-    // Initialize user from sessionStorage
-    const [user, setUser] = useState(() => {
-        if (typeof window !== "undefined") {
-            const storedUser = sessionStorage.getItem('user');
-            return storedUser ? JSON.parse(storedUser) : null;
-        }
-        return null;
-    });
-
-    // Update sessionStorage whenever user changes
-    useEffect(() => {
-        if (user) {
-            sessionStorage.setItem('user', JSON.stringify({ id: user._id, email: user.email, isVerified: user.isVerified, role: user.role }));
-        } else {
-            sessionStorage.removeItem('user');
-        }
-    }, [user]);
+    const [user, setUser] = useState(null);
 
     const handleLogout = () => {
         setUser(null);

--- a/src/utils/UserContext.js
+++ b/src/utils/UserContext.js
@@ -20,6 +20,9 @@ export const UserProvider = ({ children }) => {
         onError: () => handleLogout(), // Logout on error
     });
 
+    // values for incomplete user data, used in registration and verification pages
+    const [incompleteUser, setIncompleteUser] = useState(null);
+
     const [role, setRole] = useState(null);
 
 
@@ -42,6 +45,8 @@ export const UserProvider = ({ children }) => {
             isLoading,
             isError,
             valid,
+            incompleteUser,
+            setIncompleteUser,
             refetch,
             handleLogout,
             setUser: updateUser

--- a/src/utils/UserContext.js
+++ b/src/utils/UserContext.js
@@ -1,25 +1,51 @@
 'use client';
 
-import { useQueryClient } from "@tanstack/react-query";
-import { createContext, useContext, useEffect, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { createContext, useContext, useState } from "react";
 import { globalLogout } from "./logout";
+import { fetchCurrentUser } from "@/app/api/usersApi";
+
 
 const userContext = createContext();
 
-export const UserProvider = ({ children }) => {
-    const [valid, setValid] = useState(false);
+export const UserProvider = ({ children }) => {   
     const queryClient = useQueryClient(); // Access the QueryClient
-    const [user, setUser] = useState(null);
+ 
+    const [valid, setValid] = useState(false);
+
+    const { data: user, isError, isLoading, refetch } = useQuery({
+        queryKey: ["user"],
+        queryFn: fetchCurrentUser,
+        retry: false,
+        onError: () => handleLogout(), // Logout on error
+    });
+
+    const [role, setRole] = useState(null);
+
 
     const handleLogout = () => {
-        setUser(null);
-        setValid(false);
+        sessionStorage.removeItem("role");
         queryClient.clear();
         globalLogout();
     };
 
+    const updateUser = (newUser) => {
+        setRole(newUser.role || "guest");
+        setValid(true);
+        sessionStorage.setItem("role", newUser.role || "guest");
+    };
+
     return (
-        <userContext.Provider value={{ user, setUser, handleLogout, valid, setValid }}>
+        <userContext.Provider value={{
+            user,
+            role: user?.role || role,
+            isLoading,
+            isError,
+            valid,
+            refetch,
+            handleLogout,
+            setUser: updateUser
+        }}>
             {children}
         </userContext.Provider>
     );

--- a/src/utils/UserContext.js
+++ b/src/utils/UserContext.js
@@ -1,7 +1,7 @@
 'use client';
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { createContext, useContext, useState } from "react";
+import { createContext, useContext, useEffect, useState } from "react";
 import { globalLogout } from "./logout";
 import { fetchCurrentUser } from "@/app/api/usersApi";
 
@@ -21,7 +21,20 @@ export const UserProvider = ({ children }) => {
     });
 
     // values for incomplete user data, used in registration and verification pages
-    const [incompleteUser, setIncompleteUser] = useState(null);
+    // Load initial value from sessionStorage if available
+    const [incompleteUser, setIncompleteUserState] = useState(() => {
+        const savedValue = sessionStorage.getItem('incompleteUser');
+        return savedValue ? JSON.parse(savedValue) : null;
+    });
+
+    const setIncompleteUser = (value) => {
+        setIncompleteUserState(value);
+        if (value === null) {
+            sessionStorage.removeItem('incompleteUser');
+        } else {
+            sessionStorage.setItem('incompleteUser', JSON.stringify(value));
+        }
+    };
 
     const [role, setRole] = useState(null);
 

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -3,6 +3,7 @@ import { globalLogout } from './logout';
 
 const apiClient = axios.create({
     baseURL: process.env.NEXT_PUBLIC_BANK_API_BASE_URL,
+    withCredentials: true,
 });
 
 apiClient.interceptors.response.use(

--- a/src/utils/logout.js
+++ b/src/utils/logout.js
@@ -1,6 +1,12 @@
+import apiClient from "./api";
 
-export const globalLogout = () => {
-    document.cookie = 'token=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT';
-    sessionStorage.clear();
-    window.location.replace('/login');
+export const globalLogout = async () => {
+    
+    try {
+        await apiClient.post('/auth/logout');
+        window.location.replace('/login');
+    }
+    catch(error){
+        console.error('Failed to logout:', error.response?.data?.message || error);
+    }
 };


### PR DESCRIPTION
Made the move to httpOnly cookies to handle token, user role and userId between client and server, as it is more secure than the previous method (sessionStorage).

This is a relatively big change and so many bugs and errors were fixed within this branch, and it is possible more will pop up in the future, but it is stable enough to be merged.

NOTE: Currently there's only one place where sessionStorage is used: User verification after registration.
It's used temporarily and the data saved is minimal, but in the future there needs to be consideration to improve this. 